### PR TITLE
Changed http fetch setting from 'no-cors' to 'cors'

### DIFF
--- a/src/renderer/webapi/apis/AuthAPI.ts
+++ b/src/renderer/webapi/apis/AuthAPI.ts
@@ -37,7 +37,7 @@ export class AuthAPI {
         const url = new URL(CATE_HUB_TOKEN_URL);
         console.log('POST: ', url);
         return fetch(url.toString(), {
-            mode: 'no-cors',
+            mode: 'cors',
             method: 'post',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({username, password}),


### PR DESCRIPTION
When accepting this PR cate-webui will use the http fetch mode "cors" instead of "no-cors". 