### PR TITLE
Close #16 and fix sub-issues of #4

### DIFF
--- a/src/renderer/containers/AppLoginPage.tsx
+++ b/src/renderer/containers/AppLoginPage.tsx
@@ -3,8 +3,22 @@ import { CSSProperties } from 'react';
 import { connect, Dispatch } from 'react-redux';
 import * as actions from '../actions';
 import { Button, InputGroup, Intent } from '@blueprintjs/core';
+import cateIcon from '../resources/cate-icon-512.png';
 import { State } from '../state';
 
+const CENTER_DIV_STYLE: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '100%',
+};
+
+const BOX_STYLE: CSSProperties = {
+    display: 'flex',
+    flexFlow: 'column nowrap',
+    alignItems: 'stretch'
+};
 
 interface IDispatch {
     dispatch: Dispatch<State>;
@@ -22,97 +36,93 @@ function mapStateToProps(state: State): IAppLoginPageProps {
     };
 }
 
-class _AppLoginPage extends React.PureComponent<IAppLoginPageProps & IDispatch, null> {
-    static readonly CENTER_DIV_STYLE: CSSProperties = {
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        height: '100%',
-    };
-    static readonly BOX_STYLE: CSSProperties = {
-        display: 'flex',
-        flexFlow: 'column nowrap',
-        alignItems: 'center'
+const _AppLoginPage: React.FC<IAppLoginPageProps & IDispatch> = (props) => {
+    const password = props.password;
+    const username = props.username;
+
+    const login = () => {
+        props.dispatch(actions.login() as any);
     };
 
-    render() {
-        const password = this.props.password;
-        const username = this.props.username;
+    const back = () => {
+        props.dispatch(actions.setWebAPIProvision(null) as any);
+    };
 
-        const login = () => {
-            this.props.dispatch(actions.login() as any);
-        };
+    const setUsername = (username: string) => {
+        props.dispatch(actions.setUserCredentials(username, password));
+    };
 
-        const back = () => {
-            this.props.dispatch(actions.setWebAPIMode(null) as any);
-        };
+    const setPassword = (password: string) => {
+        props.dispatch(actions.setUserCredentials(username, password));
+    };
 
-        const setUsername = (username: string) => {
-            this.props.dispatch(actions.setUserCredentials(username, password));
-        };
+    const hasCredentials = !!(username && password);
 
-        const setPassword = (password: string) => {
-            this.props.dispatch(actions.setUserCredentials(username, password));
-        };
+    return (
+        <div style={CENTER_DIV_STYLE}>
+            <div style={BOX_STYLE}>
+                <h2 style={{textAlign: 'center'}}>CateHub Login</h2>
 
-        const hasCredentials = !!(username && password);
+                <div style={{marginTop: 12, alignContent: 'center', textAlign: 'center'}}>
+                    <img src={cateIcon} width={128} height={128} alt={'Cate icon'}/>
+                </div>
 
-        return (
-            <div style={_AppLoginPage.CENTER_DIV_STYLE}>
-                <div style={_AppLoginPage.BOX_STYLE}>
-                    <h2>CateHub Login</h2>
+                {/*<div style={{marginTop: 24, alignContent: 'center', textAlign: 'center', display: 'flex'}}>*/}
+                {/*<img width={32} height={32} src={'resources/resources/github-120.png'} alt={'github icon'}/>*/}
+                {/*<span>&nbsp;&nbsp;&nbsp;</span>*/}
+                {/*<Button onClick={signIn} intent={Intent.PRIMARY} className={'bp3-large'}>Using your GitHub*/}
+                {/*Account</Button>*/}
+                {/*</div>*/}
+                {/*<h4 style={{marginTop: 24}}>or</h4>*/}
+                {/*<p style={{marginTop: 24, alignSelf: 'center'}}>Using your CateHub Account</p>*/}
 
-                    {/*<div style={{marginTop: 24, alignContent: 'center', textAlign: 'center', display: 'flex'}}>*/}
-                    {/*<img width={32} height={32} src={'resources/resources/github-120.png'} alt={'github icon'}/>*/}
-                    {/*<span>&nbsp;&nbsp;&nbsp;</span>*/}
-                    {/*<Button onClick={signIn} intent={Intent.PRIMARY} className={'bp3-large'}>Using your GitHub*/}
-                    {/*Account</Button>*/}
-                    {/*</div>*/}
-                    {/*<h4 style={{marginTop: 24}}>or</h4>*/}
-                    {/*<p style={{marginTop: 24, alignSelf: 'center'}}>Using your CateHub Account</p>*/}
-
-                    <div style={{marginTop: 12, alignSelf: 'stretch', width: '20em'}}>
-                        <InputGroup
-                            className={'bp3-large'}
-                            placeholder="Enter your username..."
-                            type={'text'}
-                            leftIcon={'user'}
-                            value={username || ''}
-                            onChange={(event) => setUsername(event.target.value)}
-                        />
-                    </div>
-                    <div style={{marginTop: 6, alignSelf: 'stretch', width: '20em'}}>
-                        <InputGroup
-                            className={'bp3-large'}
-                            placeholder="Enter your password..."
-                            type={'password'}
-                            leftIcon={'key'}
-                            value={password || ''}
-                            onChange={(event) => setPassword(event.target.value)}
-                        />
-                    </div>
-                    <div style={{marginTop: 8, alignSelf: 'flex-end'}}>
-                        <Button
-                            icon={'arrow-left'}
-                            style={{marginRight: 6}}
-                            onClick={back}
-                            disabled={!hasCredentials}>Back</Button>
-                        <Button
-                            icon={'log-in'}
-                            intent={Intent.PRIMARY}
-                            onClick={login}
-                            disabled={!hasCredentials}
-                            autoFocus={true}>Login</Button>
-                    </div>
-                    <div style={{marginTop: 18, alignSelf: 'center'}}>
-                        <span>Don't have an account yet?&nbsp;</span><a
-                        href={'mailto:climate.office@esa.int?subject=Apply%20for%20ESA%20CCI%20Toolbox'}>Apply!</a>
-                    </div>
+                <div style={{marginTop: 12, alignSelf: 'stretch', width: '20em'}}>
+                    <InputGroup
+                        className={'bp3-large'}
+                        placeholder="Enter your username..."
+                        type={'text'}
+                        leftIcon={'user'}
+                        value={username || ''}
+                        onChange={(event) => setUsername(event.target.value)}
+                    />
+                </div>
+                <div style={{marginTop: 6, alignSelf: 'stretch', width: '20em'}}>
+                    <InputGroup
+                        className={'bp3-large'}
+                        placeholder="Enter your password..."
+                        type={'password'}
+                        leftIcon={'key'}
+                        value={password || ''}
+                        onChange={(event) => setPassword(event.target.value)}
+                    />
+                </div>
+                <div style={{marginTop: 8, alignSelf: 'flex-end'}}>
+                    <Button
+                        className={'bp3-large'}
+                        icon={'arrow-left'}
+                        style={{marginRight: 6}}
+                        onClick={back}
+                    >
+                        Back
+                    </Button>
+                    <Button
+                        className={'bp3-large'}
+                        icon={'log-in'}
+                        intent={Intent.PRIMARY}
+                        onClick={login}
+                        disabled={!hasCredentials}
+                        autoFocus={true}
+                    >
+                        Login
+                    </Button>
+                </div>
+                <div style={{marginTop: 18, alignSelf: 'center'}}>
+                    <span>Don't have an account yet?&nbsp;</span><a
+                    href={'mailto:climate.office@esa.int?subject=Apply%20for%20ESA%20CCI%20Toolbox'}>Apply!</a>
                 </div>
             </div>
-        );
-    }
+        </div>
+    );
 }
 
 const AppLoginPage = connect(mapStateToProps)(_AppLoginPage);

--- a/src/renderer/containers/AppModePage.tsx
+++ b/src/renderer/containers/AppModePage.tsx
@@ -1,11 +1,27 @@
 import * as React from 'react';
-import { CSSProperties } from 'react';
+import { CSSProperties, useState } from 'react';
 import { connect, Dispatch } from 'react-redux';
+import { Button, InputGroup, Intent } from '@blueprintjs/core';
 import * as actions from '../actions';
-import { Button, Checkbox, Intent } from '@blueprintjs/core';
+import { DEFAULT_SERVICE_URL } from '../initial-state';
 import { State } from '../state';
 
 import cateIcon from '../resources/cate-icon-512.png';
+
+
+const CENTER_DIV_STYLE: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '100%',
+};
+
+const BOX_STYLE: CSSProperties = {
+    display: 'flex',
+    flexFlow: 'column nowrap',
+    alignItems: 'stretch',
+};
 
 interface IDispatch {
     dispatch: Dispatch<State>;
@@ -19,55 +35,74 @@ function mapStateToProps(state: State): IAppModePageProps {
     return {};
 }
 
-class _AppModePage extends React.PureComponent<IAppModePageProps & IDispatch, null> {
-    static readonly CENTER_DIV_STYLE: CSSProperties = {
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        height: '100%',
-    };
-    static readonly BOX_STYLE: CSSProperties = {
-        display: 'flex',
-        flexFlow: 'column nowrap',
-        alignItems: 'stretch'
+const _AppModePage: React.FC<IAppModePageProps & IDispatch> = (props) => {
+
+    const [webAPIServiceURL, setWebAPIServiceURL] = useState(DEFAULT_SERVICE_URL);
+
+    const setCustomURLMode = () => {
+        props.dispatch(actions.setWebAPIProvision('CustomURL', webAPIServiceURL) as any);
     };
 
-    render() {
+    const setCateHubMode = () => {
+        props.dispatch(actions.setWebAPIProvision('CateHub') as any);
+    };
 
-        const setLocalMode = () => {
-            this.props.dispatch(actions.setWebAPIMode('local') as any);
-        };
+    const resetURL = () => {
+        setWebAPIServiceURL(DEFAULT_SERVICE_URL);
+    };
 
-        const setRemoteMode = () => {
-            this.props.dispatch(actions.setWebAPIMode('remote') as any);
-        };
+    return (
+        <div style={CENTER_DIV_STYLE}>
+            <div style={BOX_STYLE}>
+                <h2 style={{textAlign: 'center'}}>Select Cate Service</h2>
 
-        const setRememberMyDecision = () => {
-            // TODO (forman): implement me!
-        };
+                <div style={{marginTop: 12, alignContent: 'center', textAlign: 'center'}}>
+                    <img src={cateIcon} width={128} height={128} alt={'Cate icon'}/>
+                </div>
 
-        return (
-            <div style={_AppModePage.CENTER_DIV_STYLE}>
-                <div style={_AppModePage.BOX_STYLE}>
-                    <div style={{alignContent: 'center', textAlign: 'center'}}>
-                        <img src={cateIcon} width={128} height={128} alt={'Cate icon'}/>
-                    </div>
-                    <Button className={'bp3-large'} intent={Intent.PRIMARY} style={{marginTop: 12}}
-                            onClick={setRemoteMode}>Connect to
-                        CateHub</Button>
-                    <Button className={'bp3-large'} intent={Intent.NONE} style={{marginTop: 6}}
-                            onClick={setLocalMode}>Stand-Alone
-                        Mode</Button>
-                    <div style={{marginTop: 6}}>
-                        <Checkbox checked={true} onChange={setRememberMyDecision}>Remember my decision</Checkbox>
-                    </div>
+                <div style={{marginTop: 12, alignContent: 'center', textAlign: 'center'}}>
+                    Please select a Cate service provision mode
+                </div>
+
+                <Button className={'bp3-large'}
+                        intent={Intent.PRIMARY}
+                        style={{marginTop: 16}}
+                        onClick={setCateHubMode}>
+                    CateHub Service Provider
+                </Button>
+                <Button className={'bp3-large'}
+                        style={{marginTop: 16}}
+                        disabled={!isValidURL(webAPIServiceURL)}
+                        onClick={setCustomURLMode}>
+                    Service at given URL
+                </Button>
+                <div style={{marginTop: 6}}>
+                    <InputGroup
+                        value={webAPIServiceURL}
+                        onChange={(event) => setWebAPIServiceURL(event.textValue)}
+                        placeholder="Service URL"
+                        large={true}
+                        rightElement={
+                            <Button icon={'reset'}
+                                    minimal={true}
+                                    disabled={webAPIServiceURL === DEFAULT_SERVICE_URL}
+                                    onClick={resetURL}/>
+                        }
+                    />
                 </div>
             </div>
-        );
-    }
-}
+        </div>
+    );
+};
 
 const AppModePage = connect(mapStateToProps)(_AppModePage);
 export default AppModePage;
 
+function isValidURL(value: string) {
+    try {
+        const url = new URL(value);
+        return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch (e) {
+        return false;
+    }
+}

--- a/src/renderer/containers/ApplicationPage.tsx
+++ b/src/renderer/containers/ApplicationPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CSSProperties } from 'react';
 import { connect, Dispatch } from 'react-redux';
-import { isElectron } from '../is-electron';
+import { isElectron } from '../electron';
 import AppBar from './AppBar';
 import AppLoginPage from './AppLoginPage';
 import AppModePage from './AppModePage';
@@ -25,7 +25,14 @@ import SaveWorkspaceAsDialog from './SaveWorkspaceAsDialog';
 import PreferencesDialog from './PreferencesDialog';
 import { PanelContainer, PanelContainerLayout } from '../components/PanelContainer';
 import { Panel } from '../components/Panel';
-import { AnimationViewDataState, FigureViewDataState, State, TableViewDataState, WorldViewDataState } from '../state';
+import {
+    AnimationViewDataState,
+    FigureViewDataState,
+    State,
+    TableViewDataState,
+    WebAPIProvision,
+    WorldViewDataState
+} from '../state';
 import * as actions from '../actions';
 import * as selectors from '../selectors';
 import { ViewManager, ViewRenderMap } from '../components/ViewManager';
@@ -67,14 +74,14 @@ interface IDispatch {
 }
 
 interface IApplicationPageProps {
-    webAPIMode: 'local' | 'remote' | null;
+    webAPIProvision: WebAPIProvision;
     isSignedIn: boolean | null;
     forceAppBar?: boolean;
 }
 
 function mapStateToPropsApplication(state: State): IApplicationPageProps {
     return {
-        webAPIMode: state.data.appConfig.webAPIMode,
+        webAPIProvision: state.communication.webAPIProvision,
         isSignedIn: state.communication.token != null,
         forceAppBar: state.session.forceAppBar,
     };
@@ -98,11 +105,11 @@ class _ApplicationPage extends React.PureComponent<IApplicationPageProps & IDisp
     };
 
     render() {
-        if (this.props.webAPIMode === null) {
+        if (this.props.webAPIProvision === null) {
             return (<AppModePage/>);
         }
 
-        if (this.props.webAPIMode === 'remote' && !this.props.isSignedIn) {
+        if (this.props.webAPIProvision === 'CateHub' && !this.props.isSignedIn) {
             return (<AppLoginPage/>);
         }
 

--- a/src/renderer/containers/ChooseWorkspaceDialog.tsx
+++ b/src/renderer/containers/ChooseWorkspaceDialog.tsx
@@ -20,7 +20,7 @@ interface IChooseWorkspaceDialogOwnProps {
 
 interface IChooseWorkspaceDialogProps extends IChooseWorkspaceDialogState, IChooseWorkspaceDialogOwnProps {
     isOpen: boolean;
-    isLocalWebAPI: boolean;
+    isLocalFSAllowed: boolean;
     workspaceNames: string[];
 }
 
@@ -31,10 +31,11 @@ function mapStateToProps(state: State, ownProps: IChooseWorkspaceDialogOwnProps)
     const dialogState = selectors.dialogStateSelector(ownProps.dialogId)(state) as any;
     const isOpen = dialogState.isOpen;
     const dialogId = ownProps.dialogId;
-    const isLocalWebAPI = selectors.isLocalWebAPISelector(state);
+    const isLocalFSAllowed = selectors.isLocalFSAccessAllowedSelector(state);
     let workspaceDir = dialogState.workspaceDir;
     let currentWorkspaceName = dialogState.workspaceName;
     let selectedWorkspaceName = '';
+    // TODO (forman): Fix code duplication with SelectWorkspaceDialog
     if (isOpen) {
         if (!selectors.isScratchWorkspaceSelector(state)) {
             workspaceDir = workspaceDir || selectors.workspaceDirSelector(state);
@@ -42,7 +43,7 @@ function mapStateToProps(state: State, ownProps: IChooseWorkspaceDialogOwnProps)
         }
         workspaceDir = workspaceDir || selectors.lastWorkspaceDirSelector(state);
     }
-    workspaceDir = isLocalWebAPI ? workspaceDir || '' : null;
+    workspaceDir = isLocalFSAllowed ? workspaceDir || '' : null;
     currentWorkspaceName = currentWorkspaceName || '';
     let workspaceNames: string[];
     if (state.data.workspace && state.data.workspaceNames) {
@@ -58,7 +59,7 @@ function mapStateToProps(state: State, ownProps: IChooseWorkspaceDialogOwnProps)
         selectedWorkspaceName,
         dialogId,
         isOpen,
-        isLocalWebAPI,
+        isLocalFSAllowed: isLocalFSAllowed,
         workspaceNames: workspaceNames,
         deleteEntireWorkspace: this.deleteEntireWorkspace
     };
@@ -74,6 +75,7 @@ class ChooseWorkspaceDialog extends React.Component<IChooseWorkspaceDialogProps 
             selectedWorkspaceName: '',
             deleteEntireWorkspace: true
         };
+        // TODO (forman): Fix code duplication with SelectWorkspaceDialog
         this.onCancel = this.onCancel.bind(this);
         this.onConfirm = this.onConfirm.bind(this);
         this.canConfirm = this.canConfirm.bind(this);

--- a/src/renderer/containers/GlobeView.tsx
+++ b/src/renderer/containers/GlobeView.tsx
@@ -71,7 +71,7 @@ function mapStateToProps(state: State, ownProps: IGlobeViewOwnProps): IGlobeView
         isDialogOpen: selectors.isDialogOpenSelector(state),
         showLayerTextOverlay: state.session.showLayerTextOverlay,
         debugWorldView: state.session.debugWorldView,
-        hasWebGL: state.data.appConfig.hasWebGL,
+        hasWebGL: state.data.hasWebGL,
         externalObjectStore: selectors.externalObjectStoreSelector(state),
         newPlacemarkToolType: selectors.newPlacemarkToolTypeSelector(state),
         defaultPlacemarkStyle: selectors.defaultPlacemarkStyleSelector(state),

--- a/src/renderer/containers/SelectWorkspaceDialog.tsx
+++ b/src/renderer/containers/SelectWorkspaceDialog.tsx
@@ -19,7 +19,7 @@ interface ISelectWorkspaceDialogOwnProps {
 interface ISelectWorkspaceDialogProps extends ISelectWorkspaceDialogState, ISelectWorkspaceDialogOwnProps {
     isOpen: boolean;
     isNewDialog: boolean;
-    isLocalWebAPI: boolean;
+    isLocalFSAllowed: boolean;
 }
 
 function mapStateToProps(state: State, ownProps: ISelectWorkspaceDialogOwnProps): ISelectWorkspaceDialogProps {
@@ -27,9 +27,10 @@ function mapStateToProps(state: State, ownProps: ISelectWorkspaceDialogOwnProps)
     const isOpen = dialogState.isOpen;
     const dialogId = ownProps.dialogId;
     const isNewDialog = ownProps.dialogId === 'newWorkspaceDialog';
-    const isLocalWebAPI = selectors.isLocalWebAPISelector(state);
+    const isLocalFSAllowed = selectors.isLocalFSAccessAllowedSelector(state);
     let workspaceDir = dialogState.workspaceDir;
     let workspaceName = dialogState.workspaceName;
+    // TODO (forman): Fix code duplication with ChooseWorkspaceDialog
     if (isOpen) {
         if (!selectors.isScratchWorkspaceSelector(state)) {
             workspaceDir = workspaceDir || selectors.workspaceDirSelector(state);
@@ -37,7 +38,7 @@ function mapStateToProps(state: State, ownProps: ISelectWorkspaceDialogOwnProps)
         }
         workspaceDir = workspaceDir || selectors.lastWorkspaceDirSelector(state);
     }
-    workspaceDir = isLocalWebAPI ? workspaceDir || '' : null;
+    workspaceDir = isLocalFSAllowed ? workspaceDir || '' : null;
     workspaceName = workspaceName || '';
     return {
         workspaceDir,
@@ -45,7 +46,7 @@ function mapStateToProps(state: State, ownProps: ISelectWorkspaceDialogOwnProps)
         dialogId,
         isNewDialog,
         isOpen,
-        isLocalWebAPI,
+        isLocalFSAllowed,
     };
 }
 
@@ -58,6 +59,7 @@ class SelectWorkspaceDialog extends React.Component<ISelectWorkspaceDialogProps 
     constructor(props: ISelectWorkspaceDialogProps & DispatchProp<State>) {
         super(props);
         this.state = {workspaceDir: '', workspaceName: ''};
+        // TODO (forman): Fix code duplication with ChooseWorkspaceDialog
         this.onCancel = this.onCancel.bind(this);
         this.onConfirm = this.onConfirm.bind(this);
         this.canConfirm = this.canConfirm.bind(this);
@@ -65,7 +67,7 @@ class SelectWorkspaceDialog extends React.Component<ISelectWorkspaceDialogProps 
         this.onWorkspaceNameChange = this.onWorkspaceNameChange.bind(this);
         this.onWorkspaceDirChange = this.onWorkspaceDirChange.bind(this);
         this.showSelectDirectoryDialog = this.showSelectDirectoryDialog.bind(this);
-        this.localWebAPI = props.isLocalWebAPI;
+        this.localWebAPI = props.isLocalFSAllowed;
     }
 
     componentWillReceiveProps(nextProps: ISelectWorkspaceDialogProps) {
@@ -151,7 +153,7 @@ class SelectWorkspaceDialog extends React.Component<ISelectWorkspaceDialogProps 
         }
 
         let directoryChooser = null;
-        if (this.props.isLocalWebAPI) {
+        if (this.props.isLocalFSAllowed) {
             directoryChooser = (
                 <React.Fragment>
                     <p style={{marginTop: '1em'}}>Workspace parent directory:</p>

--- a/src/renderer/containers/StatusBar.tsx
+++ b/src/renderer/containers/StatusBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CSSProperties } from 'react';
 import { connect, DispatchProp } from 'react-redux';
-import { GeographicPosition, State, TaskState, WebAPIMode, WebAPIStatus } from '../state';
+import { GeographicPosition, State, TaskState, WebAPIProvision, WebAPIStatus } from '../state';
 import * as selectors from '../selectors';
 import * as actions from '../actions';
 import {
@@ -19,7 +19,8 @@ import TaskComponent from './TaskComponent';
 
 interface IStatusBarProps {
     webAPIStatus: WebAPIStatus;
-    webAPIMode: WebAPIMode;
+    webAPIProvision: WebAPIProvision;
+    webAPIServiceURL: string;
     tasks: { [jobId: number]: TaskState };
     globePosition: GeographicPosition | null;
 }
@@ -33,7 +34,8 @@ interface IStatusBarDispatch {
 function mapStateToProps(state: State): IStatusBarProps {
     return {
         webAPIStatus: state.communication.webAPIStatus,
-        webAPIMode: state.data.appConfig.webAPIMode,
+        webAPIProvision: state.communication.webAPIProvision,
+        webAPIServiceURL: state.communication.webAPIServiceURL,
         tasks: state.communication.tasks,
         globePosition: selectors.globeMousePositionSelector(state) || selectors.globeViewPositionSelector(state),
     };
@@ -158,9 +160,9 @@ class StatusBar extends React.Component<IStatusBarProps & IStatusBarDispatch & D
     }
 
     private renderBackendStatus() {
-        let icon: IconName | null = null;
-        let tooltipText = null;
-        const mode = ` (${this.props.webAPIMode})`;
+        let icon: IconName;
+        let tooltipText;
+        const mode = ` (${this.props.webAPIServiceURL})`;
         if (this.props.webAPIStatus === 'connecting') {
             icon = 'link';
             tooltipText = 'Connecting' + mode;

--- a/src/renderer/containers/editor/FileValueEditor.tsx
+++ b/src/renderer/containers/editor/FileValueEditor.tsx
@@ -32,7 +32,7 @@ export class FileValueEditor extends React.PureComponent<IFileValueEditorProps, 
             <ControlGroup style={FileValueEditor.DIV_STYLE}>
                 <TextField style={FileValueEditor.TEXT_FIELD_STYLE}
                            value={value}
-                           placeholder="Enter local file path"
+                           placeholder="Enter file path"
                            onChange={value => onChange(input, value)}
                            nullable={this.props.input.nullable}
                 />

--- a/src/renderer/electron.ts
+++ b/src/renderer/electron.ts
@@ -7,4 +7,14 @@ export function isElectron() {
     return _isElectron;
 }
 
-console.log('isElectron? ', isElectron(), navigator.userAgent);
+console.log('isElectron? ', isElectron());
+
+export function requireElectron(): any | null {
+    let electron;
+    try {
+        electron = require('electron');
+    } catch (error) {
+        electron = null;
+    }
+    return electron;
+}

--- a/src/renderer/initial-state.ts
+++ b/src/renderer/initial-state.ts
@@ -5,28 +5,21 @@ import {
     LocationState,
     SessionState,
     STYLE_CONTEXT_ENTITY,
-    WebAPIConfig,
     WorldViewDataState
 } from './state';
 import { hasWebGL, MY_PLACES_LAYER, newWorldView } from './state-util';
 import { SimpleStyle } from '../common/geojson-simple-style';
 import { ViewState } from './components/ViewState';
 
-export const DEFAULT_LOCAL_WEB_API_CONFIG: WebAPIConfig = {
-    serviceURL: 'http://localhost:9090'
-};
+export const  DEFAULT_SERVICE_URL = 'http://localhost:9090';
 
 export const INITIAL_DATA_STATE: DataState = {
-    appConfig: {
-        webAPIMode: null,
-        webAPIConfig: {...DEFAULT_LOCAL_WEB_API_CONFIG},
-        hasWebGL: hasWebGL(),
-    },
     dataStores: null,
     operations: null,
     workspace: null,
     colorMaps: null,
-    workspaceNames: null
+    workspaceNames: null,
+    hasWebGL: hasWebGL(),
 };
 
 const INITIAL_WORLD_VIEW: ViewState<WorldViewDataState> = newWorldView();
@@ -114,7 +107,10 @@ export const INITIAL_SESSION_STATE: SessionState = {
 };
 
 export const INITIAL_COMMUNICATION_STATE: CommunicationState = {
+    webAPIProvision: null,
+    webAPIServiceURL: DEFAULT_SERVICE_URL,
     webAPIStatus: null,
+    webAPIServiceInfo: null,
     webAPIClient: null,
     tasks: {},
     // username: 'norman',

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -5,16 +5,12 @@ import { createLogger } from 'redux-logger';
 import thunkMiddleware from 'redux-thunk';
 import { Provider } from 'react-redux';
 import ApplicationPage from './containers/ApplicationPage'
+import { requireElectron } from './electron';
 import { State } from './state';
 import * as actions from './actions'
 import { stateReducer } from './reducers';
 
-let electron;
-try {
-    electron = require('electron');
-} catch (error) {
-    electron = null;
-}
+const electron = requireElectron();
 
 export function main() {
     const middlewares: Middleware[] = [thunkMiddleware];

--- a/src/renderer/reducers.ts
+++ b/src/renderer/reducers.ts
@@ -1,5 +1,4 @@
 import { combineReducers, Reducer } from 'redux';
-import { isElectron } from './is-electron';
 import {
     CommunicationState,
     ControlState,
@@ -76,34 +75,10 @@ const updateDataStores = (state: DataState, action: Action, createDataSources: (
 
 const dataReducer = (state: DataState = INITIAL_DATA_STATE, action: Action) => {
     switch (action.type) {
-        case actions.SET_WEBAPI_MODE: {
-            const webAPIMode = action.payload.webAPIMode;
-            const appConfig = {...state.appConfig, webAPIMode};
-            return {...state, appConfig};
-        }
-        case actions.SET_WEBAPI_CONFIG: {
-            const webAPIConfig = action.payload.webAPIConfig;
-            const appConfig = {...state.appConfig, webAPIConfig};
-            return {...state, appConfig};
-        }
-        case actions.LOGOUT: {
-            if (isElectron()) {
-                const appConfig = {...state.appConfig, webAPIMode: null};
-                return {...state, appConfig};
-            }
-            return state;
-        }
         case actions.UPDATE_WORKSPACE_NAMES: {
             const workspaceNames = action.payload.workspaceNames || null;
             return {...state, workspaceNames};
         }
-        case actions.UPDATE_INITIAL_STATE:
-            const webAPIConfig = action.payload.webAPIConfig;
-            if (!!webAPIConfig) {
-                const appConfig = {...state.appConfig, webAPIConfig};
-                return {...state, appConfig};
-            }
-            return state;
         case actions.UPDATE_OPERATIONS: {
             const operations = action.payload.operations;
             return updateObject(state, {operations});
@@ -762,10 +737,22 @@ const sessionReducer = (state: SessionState = INITIAL_SESSION_STATE, action: Act
 
 const communicationReducer = (state: CommunicationState = INITIAL_COMMUNICATION_STATE, action: Action) => {
     switch (action.type) {
+        case actions.SET_WEBAPI_PROVISION: {
+            const webAPIProvision = action.payload.webAPIProvision;
+            return {...state, webAPIProvision};
+        }
+        case actions.SET_WEBAPI_SERVICE_URL: {
+            const webAPIServiceURL = action.payload.webAPIServiceURL;
+            return {...state, webAPIServiceURL};
+        }
         case actions.SET_WEBAPI_STATUS: {
             const webAPIClient = action.payload.webAPIClient;
             const webAPIStatus = action.payload.webAPIStatus;
             return {...state, webAPIClient, webAPIStatus};
+        }
+        case actions.SET_WEBAPI_SERVER_INFO: {
+            const webAPIServerInfo = action.payload.webAPIServerInfo;
+            return {...state, webAPIServerInfo};
         }
         case actions.UPDATE_TASK_STATE:
             return updateObject(state, {
@@ -786,7 +773,7 @@ const communicationReducer = (state: CommunicationState = INITIAL_COMMUNICATION_
             return {...state, token, user};
         }
         case actions.LOGOUT: {
-            return {...state, token: null, user: null, webAPIStatus: null};
+            return {...state, token: null, user: null, webAPIStatus: null, webAPIProvision: null};
         }
     }
     return state;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -31,31 +31,22 @@ export interface State {
  * Cate's domain data which is usually received from the Cate WebAPI service.
  */
 export interface DataState {
-    appConfig: AppConfigState;
     dataStores: DataStoreState[] | null;
     operations: OperationState[] | null;
     workspace: WorkspaceState | null;
     colorMaps: ColorMapCategoryState[] | null;
     workspaceNames: string[] | null;
-}
-
-export type WebAPIMode = 'local' | 'remote' | null;
-export type WebAPIStatus = 'login' | 'launching' | 'connecting' | 'open' | 'error' | 'closed' | 'logoff' | null;
-
-
-// Maybe put it into the communication state, see http://jamesknelson.com/5-types-react-application-state/
-// and see https://github.com/trbngr/react-example-pusher
-export interface AppConfigState {
-    webAPIMode: WebAPIMode;
-    webAPIConfig: WebAPIConfig;
     hasWebGL: boolean;
 }
 
-export interface WebAPIConfig {
-    // Values read by main.ts from ./cate-config.js
-    serviceURL: string;
-    serviceFile?: string;
-    processOptions?: Object;
+export type WebAPIProvision = 'CustomURL' | 'CateHub' | null;
+export type WebAPIStatus = 'login' | 'launching' | 'connecting' | 'open' | 'error' | 'closed' | 'logoff' | null;
+
+export interface WebAPIServiceInfo {
+    name: string;
+    version: string;
+    timestamp: string;
+    userRootMode: boolean;
 }
 
 export interface DataStoreNotice {
@@ -637,6 +628,9 @@ export interface ColorMapCategoryState {
  * Communication state is the status of any not-yet-complete requests to other services.
  */
 export interface CommunicationState {
+    webAPIProvision: WebAPIProvision;
+    webAPIServiceURL: string;
+    webAPIServiceInfo: WebAPIServiceInfo | null;
     webAPIStatus: WebAPIStatus;
     webAPIClient: WebAPIClient | null;
     username: string | null;

--- a/src/renderer/webapi/apis/AuthAPI.ts
+++ b/src/renderer/webapi/apis/AuthAPI.ts
@@ -1,5 +1,4 @@
 import { HttpError } from '../HttpError';
-import { WebAPIConfig } from '../../state';
 
 const CATE_HUB_SERVER_BASE = 'https://catehub.192.171.139.57.nip.io';
 const CATE_HUB_USER_WEBAPI_URL = CATE_HUB_SERVER_BASE + '/user/{username}';
@@ -28,10 +27,8 @@ export interface User {
 
 export class AuthAPI {
     // noinspection JSMethodCanBeStatic
-    getWebAPIConfig(username: string): WebAPIConfig {
-        return {
-            serviceURL: new URL(CATE_HUB_USER_WEBAPI_URL.replace('{username}', username)).toString(),
-        };
+    getWebAPIServiceURL(username: string): string {
+        return new URL(CATE_HUB_USER_WEBAPI_URL.replace('{username}', username)).toString();
     }
 
     auth(username: string, password: string): Promise<AuthInfo> {

--- a/src/renderer/webapi/apis/ServiceInfoAPI.ts
+++ b/src/renderer/webapi/apis/ServiceInfoAPI.ts
@@ -1,0 +1,26 @@
+import { HttpError } from '../HttpError';
+import { WebAPIServiceInfo } from '../../state';
+
+
+export class ServiceInfoAPI {
+
+    getServiceInfo(serviceURL: string): Promise<WebAPIServiceInfo> {
+        const url = new URL(serviceURL + "/");
+        console.log('GET: ', url);
+        return fetch(url.toString())
+            .then((response: Response) => {
+                if (!response.ok) {
+                    throw HttpError.fromResponse(response);
+                }
+                return response.json() as Promise<any>;
+            })
+            .then((webAPIServiceInfo: any) => {
+                return {
+                    name: webAPIServiceInfo.name,
+                    version: webAPIServiceInfo.version,
+                    timestamp: webAPIServiceInfo.timestamp,
+                    userRootMode: webAPIServiceInfo.user_root_mode
+                };
+            });
+    }
+}


### PR DESCRIPTION
**Important note**: First checkout and review https://github.com/CCI-Tools/cate/pull/876!

In this PR:

- Closes #16
- Some items of #4 no longer apply
- Using new "user_root_mode" flag (see #16) from service info to decide whether we can show native OS desktop file choosers
- Removed "remember my decision" checkbox from service provision mode page, as this is no longer applicable
- Style adjustments to service provision mode page and login page
- Lots of code refactorings & simplifications w.r.t. Cate web API service configuration
