### PR TITLE
cate-webui-56: No data sources shown right after starting on localhost

### DIFF
--- a/src/renderer/actions.ts
+++ b/src/renderer/actions.ts
@@ -319,9 +319,9 @@ export function connectWebAPIClient(): ThunkAction {
             dispatch(setWebAPIStatus('open', webAPIClient));
             dispatch(loadBackendConfig());
             dispatch(loadColorMaps());
+            dispatch(loadPreferences());
             dispatch(loadDataStores());
             dispatch(loadOperations());
-            dispatch(loadPreferences());
         };
 
         const formatMessage = (message: string, event: any): string => {


### PR DESCRIPTION
Solves #56. At least I was not able to reproduce the problem after this change.