### PR TITLE
Changed hard coded CATEHUB config url to a React env variable

### DIFF
--- a/.env
+++ b/.env
@@ -13,4 +13,4 @@
 #REACT_APP_WEB_API_SERVICE_URL=http://localhost:9090
 
 # Set URL of the Cate Hub instance.
-#REACT_APP_HUB_SERVER_BASE=http://localhost:9090
+#REACT_APP_HUB_SERVER_BASE=http://localhost:9092

--- a/.env
+++ b/.env
@@ -11,3 +11,6 @@
 # Then the value for REACT_APP_WEB_API_CUSTOM_URL would be "http://localhost:9090".
 #
 #REACT_APP_WEB_API_SERVICE_URL=http://localhost:9090
+
+# Set URL of the Cate Hub instance.
+#REACT_APP_HUB_SERVER_BASE=http://localhost:9090

--- a/src/renderer/webapi/apis/AuthAPI.ts
+++ b/src/renderer/webapi/apis/AuthAPI.ts
@@ -1,6 +1,6 @@
 import { HttpError } from '../HttpError';
 
-const DEFAULT_CATE_HUB_SERVER_BASE = 'http://localhost:9090'
+const DEFAULT_CATE_HUB_SERVER_BASE = 'http://localhost:9092'
 const CATE_HUB_SERVER_BASE = process.env.REACT_APP_HUB_SERVER_BASE || DEFAULT_CATE_HUB_SERVER_BASE;
 const CATE_HUB_USER_WEBAPI_URL = CATE_HUB_SERVER_BASE + '/user/{username}';
 const CATE_HUB_TOKEN_URL = CATE_HUB_SERVER_BASE + '/hub/api/authorizations/token';

--- a/src/renderer/webapi/apis/AuthAPI.ts
+++ b/src/renderer/webapi/apis/AuthAPI.ts
@@ -1,7 +1,7 @@
-import { DEFAULT_SERVICE_URL } from '../../initial-state';
 import { HttpError } from '../HttpError';
 
-const CATE_HUB_SERVER_BASE = process.env.REACT_APP_WEB_API_SERVICE_URL || DEFAULT_SERVICE_URL;
+const DEFAULT_CATE_HUB_SERVER_BASE = 'http://localhost:9090'
+const CATE_HUB_SERVER_BASE = process.env.REACT_APP_HUB_SERVER_BASE || DEFAULT_CATE_HUB_SERVER_BASE;
 const CATE_HUB_USER_WEBAPI_URL = CATE_HUB_SERVER_BASE + '/user/{username}';
 const CATE_HUB_TOKEN_URL = CATE_HUB_SERVER_BASE + '/hub/api/authorizations/token';
 const CATE_HUB_USER_SERVER_URL = CATE_HUB_SERVER_BASE + '/hub/api/users/{username}/server';


### PR DESCRIPTION
When accepting this PR cate webui athentication will use an env variable to configure the catehub URL. That was previsouly hard coded