### PR TITLE
Forman 128 maintenance mode

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,10 @@ SKIP_PREFLIGHT_CHECK=true
 # REACT_APP_KEYCLOAK_REALM=
 # REACT_APP_KEYCLOAK_CLIENT_ID=
 
+# If this is set, CateHub access will be disabled.
+# Its value is a reason message.
+# REACT_APP_CATEHUB_MAINTENANCE=Sorry, the Cate cloud service is temporarily unavailable due to maintenance. However, you can still use a local service.
+
 # Set maximum number of concurrent users
 # REACT_APP_MAX_NUM_USERS=50
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ### Changes 2.2.1 (in dev)
 
+* Allow disabling Cate cloud service usage and display a maintenance 
+  message instead. Can be activated by a new setting in `.env`:
+  ```
+    REACT_APP_CATEHUB_MAINTENANCE=Sorry, the Cate cloud service is temporarily unavailable ... 
+  ```
+
 ### Changes 2.2.0
 
 * Using Keycloak authentication and user management service 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ### Changes 2.2.1 (in dev)
 
 * Allow disabling Cate cloud service usage and display a maintenance 
-  message instead. Can be activated by a new setting in `.env`:
+  message instead. Can be activated by a new setting in `.env` (#128):
   ```
     REACT_APP_CATEHUB_MAINTENANCE=Sorry, the Cate cloud service is temporarily unavailable ... 
   ```

--- a/src/renderer/containers/AppModePage.tsx
+++ b/src/renderer/containers/AppModePage.tsx
@@ -3,7 +3,7 @@ import { CSSProperties, useEffect, useState } from 'react';
 import { connect, Dispatch } from 'react-redux';
 import { useHistory } from "react-router-dom";
 import { useKeycloak } from '@react-keycloak/web'
-import { Button, InputGroup, Intent, Spinner, Tooltip } from '@blueprintjs/core';
+import { Button, Checkbox, Icon, InputGroup, Intent, Spinner, Tooltip } from '@blueprintjs/core';
 
 import { TermsAndConditions } from '../components/TermsAndConditions';
 import { DEFAULT_SERVICE_URL } from '../initial-state';
@@ -11,6 +11,8 @@ import { State } from '../state';
 
 import cateIcon from '../resources/cate-icon-512.png';
 
+
+const maintenanceReason: string | undefined = process.env.REACT_APP_CATEHUB_MAINTENANCE;
 
 const CENTER_DIV_STYLE: CSSProperties = {
     display: 'flex',
@@ -48,6 +50,7 @@ const _AppModePage: React.FC<IAppModePageProps & IDispatch> = () => {
     const history = useHistory();
     const [, keycloakInitialized] = useKeycloak();
     const [webAPIServiceURL, setWebAPIServiceURL] = useState(DEFAULT_SERVICE_URL);
+    const [termsAndConditionsAgreed, setTermsAndConditionsAgreed] = useState(false);
 
     useEffect(() => {
         try {
@@ -73,6 +76,10 @@ const _AppModePage: React.FC<IAppModePageProps & IDispatch> = () => {
         history.push('/hub')
     };
 
+    const handleTermsAndConditionsAgreedChange = (e: React.FormEvent<HTMLInputElement>) => {
+        setTermsAndConditionsAgreed(e.currentTarget.checked);
+    };
+
     const resetURL = () => {
         setWebAPIServiceURL(DEFAULT_SERVICE_URL);
     };
@@ -86,15 +93,21 @@ const _AppModePage: React.FC<IAppModePageProps & IDispatch> = () => {
                     <img src={cateIcon} width={128} height={128} alt={'Cate icon'}/>
                 </div>
 
-                <div style={{marginTop: 12, alignContent: 'center', textAlign: 'center'}}>
-                    Please select a Cate service provision mode
-                </div>
+                {maintenanceReason ? (
+                    <div style={{marginTop: 12, alignContent: 'center', textAlign: 'center', maxWidth: 320}}>
+                        <Icon icon="warning-sign" intent={Intent.WARNING}/>&nbsp;{maintenanceReason}
+                    </div>
+                ) : (
+                    <div style={{marginTop: 12, alignContent: 'center', textAlign: 'center', maxWidth: 320}}>
+                        Please select a Cate service provision mode
+                    </div>
+                )}
                 <Button className={'bp3-large'}
                         intent={Intent.PRIMARY}
                         style={{marginTop: 18}}
                         onClick={setCateHubMode}
-                        disabled={!keycloakInitialized}
-                        rightIcon={!keycloakInitialized && <Spinner size={16}/>}
+                        disabled={!keycloakInitialized || !termsAndConditionsAgreed || Boolean(maintenanceReason)}
+                        rightIcon={maintenanceReason ? null : !keycloakInitialized && <Spinner size={16}/>}
                 >
                     <Tooltip content={<div>Obtain a new Cate service instance<br/>in the cloud (CateHub
                         Software-as-a-Service).<br/>Requires login information.</div>}>
@@ -102,7 +115,13 @@ const _AppModePage: React.FC<IAppModePageProps & IDispatch> = () => {
                     </Tooltip>
                 </Button>
                 <div style={SA_MODE_LINK_STYLE}>
-                    <TermsAndConditions/>
+                    <Checkbox
+                        checked={termsAndConditionsAgreed}
+                        onChange={handleTermsAndConditionsAgreedChange}
+                        disabled={Boolean(maintenanceReason)}
+                    >
+                        I agree to the&nbsp;<TermsAndConditions/>
+                    </Checkbox>
                 </div>
                 <Button className={'bp3-large'}
                         style={{marginTop: 18}}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -4,6 +4,7 @@ import {
     BrowserRouter as Router,
     // HashRouter as Router,
     Switch,
+    Redirect,
     Route,
 } from "react-router-dom";
 import { Provider as StoreProvider } from 'react-redux';
@@ -21,7 +22,9 @@ import { stateReducer } from './reducers';
 import { State } from './state';
 import { isElectron } from './electron';
 
+
 const keycloak = Keycloak(getKeycloakConfig());
+const maintenanceReason: string | undefined = process.env.REACT_APP_CATEHUB_MAINTENANCE;
 
 const keycloakProviderInitConfig: KeycloakInitOptions = {
     onLoad: 'check-sso',
@@ -75,7 +78,11 @@ export function main() {
                                 <AppModePage/>
                             </Route>
                             <Route path="/hub">
-                                <AppMainPageForHub/>
+                                {
+                                    maintenanceReason
+                                    ? (<Redirect to="/"/>)
+                                    : (<AppMainPageForHub/>)
+                                }
                             </Route>
                             <Route path="/sa">
                                 <AppMainPageForSA/>


### PR DESCRIPTION
* Allow disabling Cate cloud service usage and display a maintenance 
  message instead. Can be activated by a new setting in `.env` (#128):
  ```
    REACT_APP_CATEHUB_MAINTENANCE=Sorry, the Cate cloud service is temporarily unavailable ... 
  ```

@dzelge, upon approval, we'll should do a 2.1.1 release and deployment.